### PR TITLE
スレッド一覧画面｜API呼び出し実装

### DIFF
--- a/src/pages/ThreadsListPage/hooks/types.ts
+++ b/src/pages/ThreadsListPage/hooks/types.ts
@@ -1,0 +1,10 @@
+export type Thread = {
+  id: string;
+  title: string;
+};
+
+export type ApiError = {
+  ErrorCode: number;
+  ErrorMessageJP: string;
+  ErrorMessageEN: string;
+};

--- a/src/pages/ThreadsListPage/hooks/useFetchThreads.ts
+++ b/src/pages/ThreadsListPage/hooks/useFetchThreads.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import { Thread, ApiError } from "./types";
+
+export const useFetchThreads = () => {
+  const [threads, setThreads] = useState<Thread[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const fetchTheads = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetch(
+          "https://railway.bulletinboard.techtrain.dev/threads",
+        );
+
+        const data = await response.json();
+
+        if (!response.ok) {
+          const apiError = data as ApiError;
+          throw new Error(`${apiError.ErrorMessageJP} (${apiError.ErrorCode})`);
+        }
+        setThreads(data as Thread[]);
+      } catch (error) {
+        console.error("APIエラーが発生しました", error);
+        setError(
+          error instanceof Error ? error : new Error("エラーが発生しました"),
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchTheads();
+  }, []);
+
+  return { threads, isLoading, error };
+};

--- a/src/pages/ThreadsListPage/index.tsx
+++ b/src/pages/ThreadsListPage/index.tsx
@@ -1,9 +1,32 @@
 import { FC } from "react";
+import { useFetchThreads } from "./hooks/useFetchThreads";
+// import { Link } from "react-router-dom";
 
 export const ThreadsListPage: FC = () => {
+  const { threads, isLoading, error } = useFetchThreads();
+
   return (
-    <div>
-      <h1>スレッド一覧</h1>
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">スレッド一覧</h1>
+
+      {isLoading && <p className="text-gray-500">Loading...</p>}
+      {error && <p className="text-red-500">エラー: {error.message}</p>}
+
+      {!isLoading && !error && threads.length === 0 && (
+        <p className="text-gray-500">スレッドがありません</p>
+      )}
+
+      <ul>
+        {threads.map((thread) => (
+          <li key={thread.id} className="mb-2">
+            {/* <Link to={`/threads/${thread.id}`} className="text-blue-500 hover:underline"> */}
+            {thread.title}
+            {/* </Link> */}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 };
+
+export default ThreadsListPage;


### PR DESCRIPTION
close #7 

## 変更内容
- APIレスポンスの型定義を追加
  - Thread型: スレッド情報の型定義
  - ApiError型: エラーレスポンスの型定義
- スレッド一覧取得用のカスタムフック（useFetchThreads）を実装
  - APIからスレッド一覧を取得
  - ローディング状態の管理
  - エラーハンドリング

## カスタムフック
- `useFetchThreads`フックを作成し、以下の機能を実装
  - スレッド一覧の取得
  - ローディング状態の管理
  - エラーハンドリング

## 動作確認項目
- [x] スレッド一覧が正常に取得できる
- [x] ローディング中は"Loading..."が表示される
- [x] エラー時にエラーメッセージが表示される
- [ ] スレッドが0件の場合に適切なメッセージが表示される